### PR TITLE
Handling autocommit logic  

### DIFF
--- a/ossdbtoolsservice/driver/types/driver.py
+++ b/ossdbtoolsservice/driver/types/driver.py
@@ -5,7 +5,6 @@
 
 from typing import Tuple
 from abc import ABC, abstractmethod
-import mysql.connector
 
 class ServerConnection(ABC):
     """Abstract base class that outlines methods and properties that connections must implement"""
@@ -53,7 +52,7 @@ class ServerConnection(ABC):
 
     @property
     @abstractmethod
-    def database_error(self) -> mysql.connector.DatabaseError:
+    def database_error(self) -> str:
         """ Returns the type of database error this connection throws"""
 
     @property

--- a/ossdbtoolsservice/driver/types/driver.py
+++ b/ossdbtoolsservice/driver/types/driver.py
@@ -5,7 +5,7 @@
 
 from typing import Tuple
 from abc import ABC, abstractmethod
-import mysql
+import mysql.connector
 
 class ServerConnection(ABC):
     """Abstract base class that outlines methods and properties that connections must implement"""

--- a/ossdbtoolsservice/driver/types/driver.py
+++ b/ossdbtoolsservice/driver/types/driver.py
@@ -5,17 +5,12 @@
 
 from typing import Tuple
 from abc import ABC, abstractmethod
-
+import mysql
 
 class ServerConnection(ABC):
     """Abstract base class that outlines methods and properties that connections must implement"""
 
     # PROPERTIES ###########################################################
-    @property
-    @abstractmethod
-    def autocommit(self) -> bool:
-        """Returns the current autocommit status for this connection"""
-
     @property
     @abstractmethod
     def host_name(self) -> str:
@@ -58,7 +53,7 @@ class ServerConnection(ABC):
 
     @property
     @abstractmethod
-    def database_error(self) -> str:
+    def database_error(self) -> mysql.connector.DatabaseError:
         """ Returns the type of database error this connection throws"""
 
     @property
@@ -93,15 +88,6 @@ class ServerConnection(ABC):
         """
 
     # METHODS ##############################################################
-
-    @autocommit.setter
-    @abstractmethod
-    def autocommit(self, mode: bool):
-        """
-        Sets the connection's autocommit setting to the specified mode
-        :param mode: True or False
-        """
-
     @abstractmethod
     def commit(self):
         """

--- a/ossdbtoolsservice/driver/types/mysql_driver.py
+++ b/ossdbtoolsservice/driver/types/mysql_driver.py
@@ -244,13 +244,13 @@ class MySQLConnection(ServerConnection):
         with self._conn.cursor(buffered=True) as cursor:
             try:
                 cursor.execute(query)
-                if all:
-                    query_results = cursor.fetchall()
-                else:
-                    query_results = cursor.fetchone()
-                return query_results
+                if cursor.with_rows:
+                    if all:
+                        query_results = cursor.fetchall()
+                    else:
+                        query_results = cursor.fetchone()
+                    return query_results
             except Exception as e:
-                msg = e.msg
                 return False
             finally:
                 cursor.close()
@@ -268,16 +268,17 @@ class MySQLConnection(ServerConnection):
         with self._conn.cursor(buffered=True) as cursor:
             try:
                 cursor.execute(query)
-                # Get a list of column names
-                col_names: List[str] = [col[0] for col in cursor.description]
+                if cursor.with_rows:
+                    # Get a list of column names
+                    col_names: List[str] = [col[0] for col in cursor.description]
 
-                rows: List[dict] = []
-                if cursor.rowcount > 0:
-                    for row in cursor:
-                        # Map each column name to the corresponding value in each row
-                        row_dict = {col_names[index]: row for index, row in enumerate(row)}
-                        rows.append(row_dict)
-                return col_names, rows
+                    rows: List[dict] = []
+                    if cursor.rowcount > 0:
+                        for row in cursor:
+                            # Map each column name to the corresponding value in each row
+                            row_dict = {col_names[index]: row for index, row in enumerate(row)}
+                            rows.append(row_dict)
+                    return col_names, rows
             except Exception:
                 return False
             finally:

--- a/ossdbtoolsservice/driver/types/mysql_driver.py
+++ b/ossdbtoolsservice/driver/types/mysql_driver.py
@@ -69,7 +69,7 @@ def check_if_c_ext_is_used():
 class MySQLConnection(ServerConnection):
     """Wrapper for a mysql-connector connection that makes various properties easier to access"""
 
-    def __init__(self, conn_params: {}, config: Optional[Configuration] = None):
+    def __init__(self, conn_params: dict(), config: Optional[Configuration] = None):
         """
         Creates a new connection wrapper. Parses version string
         :param conn_params: connection parameters dict
@@ -109,7 +109,7 @@ class MySQLConnection(ServerConnection):
             self._connection_options['port'] = constants.DEFAULT_PORT[constants.MYSQL_PROVIDER_NAME]
 
         # Setting autocommit to True initally
-        self._autocommit_status = True
+        self._connection_options['autocommit'] = True
 
         # Pass connection parameters as keyword arguments to the connection by unpacking the connection_options dict
         try:
@@ -142,12 +142,6 @@ class MySQLConnection(ServerConnection):
             self._server_type = "MySQL"
 
     # PROPERTIES ###########################################################
-
-    @property
-    def autocommit(self) -> bool:
-        """Returns the current autocommit status for this connection"""
-        return self._autocommit_status
-
     @property
     def host_name(self) -> str:
         """Returns the hostname for the current connection"""
@@ -219,14 +213,6 @@ class MySQLConnection(ServerConnection):
         return self._conn.is_connected()
 
     # METHODS ##############################################################
-    @autocommit.setter
-    def autocommit(self, mode: bool):
-        """
-        Sets the given autocommit status for this connection
-        :param mode: True or False
-        """
-        self._autocommit_status = mode
-
     def commit(self):
         """
         Commits the current transaction
@@ -262,9 +248,6 @@ class MySQLConnection(ServerConnection):
                     query_results = cursor.fetchall()
                 else:
                     query_results = cursor.fetchone()
-                
-                if self.autocommit:
-                    self._conn.commit()
                 return query_results
             except Exception as e:
                 msg = e.msg
@@ -294,8 +277,6 @@ class MySQLConnection(ServerConnection):
                         # Map each column name to the corresponding value in each row
                         row_dict = {col_names[index]: row for index, row in enumerate(row)}
                         rows.append(row_dict)
-                if self.autocommit:
-                    self._conn.commit()
                 return col_names, rows
             except Exception:
                 return False

--- a/ossdbtoolsservice/query/batch.py
+++ b/ossdbtoolsservice/query/batch.py
@@ -121,11 +121,6 @@ class Batch:
         cursor = self.get_cursor(conn)
         try:
             cursor.execute(self.batch_text)
-
-            # Commit the transaction if autocommit is True
-            if conn.autocommit:
-                conn.commit()
-
             self.after_execute(cursor)
         except conn.database_error as error:
             self._has_error = True

--- a/ossdbtoolsservice/query/query.py
+++ b/ossdbtoolsservice/query/query.py
@@ -127,6 +127,7 @@ class Query:
 
         # Run each batch sequentially
         try:
+            # When Analyze Explain is used we have to disable auto commit
             if self._disable_auto_commit:
                 connection.execute_query('Set autocommit = 0;')
 

--- a/ossdbtoolsservice/query/query.py
+++ b/ossdbtoolsservice/query/query.py
@@ -55,7 +55,6 @@ class Query:
         self._execution_state: ExecutionState = ExecutionState.NOT_STARTED
         self._owner_uri: str = owner_uri
         self._query_text = query_text
-        self._disable_auto_commit = False
         self._current_batch_index = 0
         self._batches: List[Batch] = []
         self._execution_plan_options = query_execution_settings.execution_plan_options
@@ -79,7 +78,6 @@ class Query:
                 if self._execution_plan_options.include_estimated_execution_plan_xml:
                     sql_statement_text = Query.EXPLAIN_QUERY_TEMPLATE.format(sql_statement_text)
                 elif self._execution_plan_options.include_actual_execution_plan_xml:
-                    self._disable_auto_commit = True
                     sql_statement_text = Query.ANALYZE_EXPLAIN_QUERY_TEMPLATE.format(sql_statement_text)
 
             batch = create_batch(

--- a/ossdbtoolsservice/query/query.py
+++ b/ossdbtoolsservice/query/query.py
@@ -127,7 +127,6 @@ class Query:
 
         # Run each batch sequentially
         try:
-            current_auto_commit_status = connection.execute_query('select @@autocommit;')
             # When Analyze Explain is used we have to disable auto commit
             if self._disable_auto_commit:
                 connection.execute_query('Set autocommit = 0;')
@@ -140,8 +139,8 @@ class Query:
 
                 batch.execute(connection)
         finally:
-            if connection.open:
-                connection.execute_query('Set autocommit = {};'.format(current_auto_commit_status))
+            if connection.open and self._disable_auto_commit:
+                connection.execute_query('Set autocommit = 1;')
             self._execution_state = ExecutionState.EXECUTED
 
     def get_subset(self, batch_index: int, start_index: int, end_index: int):

--- a/ossdbtoolsservice/query/query.py
+++ b/ossdbtoolsservice/query/query.py
@@ -127,6 +127,7 @@ class Query:
 
         # Run each batch sequentially
         try:
+            current_auto_commit_status = connection.execute_query('select @@autocommit;')
             # When Analyze Explain is used we have to disable auto commit
             if self._disable_auto_commit:
                 connection.execute_query('Set autocommit = 0;')
@@ -140,7 +141,7 @@ class Query:
                 batch.execute(connection)
         finally:
             if connection.open:
-                connection.execute_query('Set autocommit = 1')
+                connection.execute_query('Set autocommit = {};'.format(current_auto_commit_status))
             self._execution_state = ExecutionState.EXECUTED
 
     def get_subset(self, batch_index: int, start_index: int, end_index: int):

--- a/ossdbtoolsservice/query/query.py
+++ b/ossdbtoolsservice/query/query.py
@@ -127,11 +127,6 @@ class Query:
 
         # Run each batch sequentially
         try:
-            current_auto_commit_status = connection.autocommit
-            # When Analyze Explain is used we have to disable auto commit
-            if self._disable_auto_commit:
-                connection.autocommit = False
-
             for batch_index, batch in enumerate(self._batches):
                 self._current_batch_index = batch_index
 
@@ -140,9 +135,6 @@ class Query:
 
                 batch.execute(connection)
         finally:
-            # We can only set autocommit when the connection is open.
-            if connection.open:
-                connection.autocommit = current_auto_commit_status
             self._execution_state = ExecutionState.EXECUTED
 
     def get_subset(self, batch_index: int, start_index: int, end_index: int):

--- a/tests/connection/test_mysql_connection_service.py
+++ b/tests/connection/test_mysql_connection_service.py
@@ -97,6 +97,7 @@ class TestMySQLConnectionService(unittest.TestCase):
             database='mysql',
             ssl_verify_cert=False,
             ssl_verify_identity=False,
+            autocommit=True
             )
 
         # Verify that mysql's connection method was called and that the

--- a/tests/driver/test_mysql_driver.py
+++ b/tests/driver/test_mysql_driver.py
@@ -51,7 +51,6 @@ class TestMySQLConnection(unittest.TestCase):
         print(mysqlConnection.connection_options)
         self.assertDictEqual(mysqlConnection.connection_options, expected_connection_options)
         self.assertIs(mysqlConnection.connection, self.mock_mysql_connection)
-        self.assertTrue(mysqlConnection.autocommit)
         self.assertEqual(mysqlConnection.default_database, constants.DEFAULT_DB[constants.MYSQL_PROVIDER_NAME])
     
     def test_mysql_connection_ssl_enable_verify_ca(self):
@@ -86,7 +85,6 @@ class TestMySQLConnection(unittest.TestCase):
         print(mysqlConnection.connection_options)
         self.assertDictEqual(mysqlConnection.connection_options, expected_connection_options)
         self.assertIs(mysqlConnection.connection, self.mock_mysql_connection)
-        self.assertTrue(mysqlConnection.autocommit)
         self.assertEqual(mysqlConnection.default_database, constants.DEFAULT_DB[constants.MYSQL_PROVIDER_NAME])
 
     def test_mysql_connection_ssl_enable_verify_identity(self):
@@ -121,7 +119,6 @@ class TestMySQLConnection(unittest.TestCase):
         print(mysqlConnection.connection_options)
         self.assertDictEqual(mysqlConnection.connection_options, expected_connection_options)
         self.assertIs(mysqlConnection.connection, self.mock_mysql_connection)
-        self.assertTrue(mysqlConnection.autocommit)
         self.assertEqual(mysqlConnection.default_database, constants.DEFAULT_DB[constants.MYSQL_PROVIDER_NAME])
 
     def test_mysql_connection_ssl_disable(self):
@@ -152,7 +149,6 @@ class TestMySQLConnection(unittest.TestCase):
         print(mysqlConnection.connection_options)
         self.assertDictEqual(mysqlConnection.connection_options, expected_connection_options)
         self.assertIs(mysqlConnection.connection, self.mock_mysql_connection)
-        self.assertTrue(mysqlConnection.autocommit)
         self.assertEqual(mysqlConnection.default_database, constants.DEFAULT_DB[constants.MYSQL_PROVIDER_NAME])
 
     def test_mysql_connection_port_provided(self):
@@ -184,7 +180,6 @@ class TestMySQLConnection(unittest.TestCase):
         print(mysqlConnection.connection_options)
         self.assertDictEqual(mysqlConnection.connection_options, expected_connection_options)
         self.assertIs(mysqlConnection.connection, self.mock_mysql_connection)
-        self.assertTrue(mysqlConnection.autocommit)
         self.assertEqual(mysqlConnection.default_database, constants.DEFAULT_DB[constants.MYSQL_PROVIDER_NAME])
 
     def test_mysql_connection_dbname_provided(self):
@@ -215,7 +210,6 @@ class TestMySQLConnection(unittest.TestCase):
         print(mysqlConnection.connection_options)
         self.assertDictEqual(mysqlConnection.connection_options, expected_connection_options)
         self.assertIs(mysqlConnection.connection, self.mock_mysql_connection)
-        self.assertTrue(mysqlConnection.autocommit)
         self.assertEqual(mysqlConnection.default_database, constants.DEFAULT_DB[constants.MYSQL_PROVIDER_NAME])
 
 

--- a/tests/driver/test_mysql_driver.py
+++ b/tests/driver/test_mysql_driver.py
@@ -47,6 +47,7 @@ class TestMySQLConnection(unittest.TestCase):
             'ssl_disabled': False,
             'ssl_verify_cert': False,
             'ssl_verify_identity': False,
+            'autocommit': True
         }
         print(mysqlConnection.connection_options)
         self.assertDictEqual(mysqlConnection.connection_options, expected_connection_options)
@@ -81,6 +82,7 @@ class TestMySQLConnection(unittest.TestCase):
             'ssl_disabled': False,
             'ssl_verify_cert': True,
             'ssl_verify_identity': False,
+            'autocommit': True
         }
         print(mysqlConnection.connection_options)
         self.assertDictEqual(mysqlConnection.connection_options, expected_connection_options)
@@ -115,6 +117,7 @@ class TestMySQLConnection(unittest.TestCase):
             'ssl_disabled': False,
             'ssl_verify_cert': False,
             'ssl_verify_identity': True,
+            'autocommit': True
         }
         print(mysqlConnection.connection_options)
         self.assertDictEqual(mysqlConnection.connection_options, expected_connection_options)
@@ -145,6 +148,7 @@ class TestMySQLConnection(unittest.TestCase):
             'port': 3306,
             'user': 'nitish',
             'ssl_disabled': True,
+            'autocommit': True
             }
         print(mysqlConnection.connection_options)
         self.assertDictEqual(mysqlConnection.connection_options, expected_connection_options)
@@ -176,6 +180,7 @@ class TestMySQLConnection(unittest.TestCase):
             'port': 3307,
             'user': 'nitish',
             'ssl_disabled': True,
+            'autocommit': True
             }
         print(mysqlConnection.connection_options)
         self.assertDictEqual(mysqlConnection.connection_options, expected_connection_options)
@@ -206,6 +211,7 @@ class TestMySQLConnection(unittest.TestCase):
             'port': 3306,
             'user': 'nitish',
             'ssl_disabled': True,
+            'autocommit': True
             }
         print(mysqlConnection.connection_options)
         self.assertDictEqual(mysqlConnection.connection_options, expected_connection_options)

--- a/tests/integration/connections_for_integration_tests.py
+++ b/tests/integration/connections_for_integration_tests.py
@@ -7,7 +7,7 @@
 
 from abc import abstractclassmethod
 from typing import List
-import mysql
+import mysql.connector
 
 
 class IConnection():

--- a/tests/integration/connections_for_integration_tests.py
+++ b/tests/integration/connections_for_integration_tests.py
@@ -46,6 +46,7 @@ class MySQLConnection:
     def open_connections(cls, connection_details_list):
         cls._connections = []
         for config_dict in connection_details_list:
+            config_dict['autocommit'] = True
             connection = mysql.connector.connect(**config_dict)
             cls._connections.append(connection)
 

--- a/tests/integration/connections_for_integration_tests.py
+++ b/tests/integration/connections_for_integration_tests.py
@@ -48,7 +48,6 @@ class MySQLConnection:
         for config_dict in connection_details_list:
             connection = mysql.connector.connect(**config_dict)
             cls._connections.append(connection)
-            connection.autocommit = True
 
     @classmethod
     def get_connections(cls):

--- a/tests/language/test_metadata_executor.py
+++ b/tests/language/test_metadata_executor.py
@@ -7,7 +7,7 @@ import unittest
 from typing import Any, List
 from unittest import mock
 
-import mysql
+import mysql.connector
 
 import tests.mysqlsmo_tests.utils as utils
 from ossdbtoolsservice.language.metadata_executor import MetadataExecutor
@@ -48,7 +48,7 @@ class MockCursor:
     def execute_failure_side_effects(self, *args):
         """Set up dummy results and raise error for query execution failure"""
         self.connection.notices = ["NOTICE: foo", "DEBUG: bar"]
-        raise mysql.DatabaseError()
+        raise mysql.connector.DatabaseError
 
     def __enter__(self):
         return self

--- a/tests/query/test_query.py
+++ b/tests/query/test_query.py
@@ -6,7 +6,7 @@
 import unittest
 from unittest import mock
 
-import mysql
+import mysql.connector
 
 from ossdbtoolsservice.query import (ExecutionState, Query, QueryEvents,
                                      QueryExecutionSettings,


### PR DESCRIPTION
**Bug Reported**:

https://github.com/microsoft/azuredatastudio-mysql/issues/100

**MySQL doc**:
https://dev.mysql.com/doc/refman/5.6/en/innodb-autocommit-commit-rollback.html

**RCA**: 
We are not using autocommit property on connection instead we have defined our own autocommit property on our connection object and committing manually.

We are autocommitting every statement executed by the user which works fine since autocommit is true by default but when user sets autocommit = false, we are not handling this situation therefore rollback is not giving the expected result.

**Fix**:
Removed the autocommit property from the connection and codespace and set autcommit=true while making the connection itself.

**Other solution**:
We keep the autocommit property on our connection object but before committing we always check whether autocommit = True/False on connection using "select @@autocommit" command. This adds an overhead on each query executions as we will have to check after each query.