### PR TITLE
updated session_uri key and fixed object explorer tab

### DIFF
--- a/ossdbtoolsservice/language/operations_queue.py
+++ b/ossdbtoolsservice/language/operations_queue.py
@@ -160,7 +160,7 @@ class OperationsQueue:
         """
         Creates a key uniquely identifying a ConnectionInfo object for use in caching
         """
-        return '{0}|{1}|{2}|{3}'.format(conn_info.details.server_name, conn_info.details.database_name, conn_info.details.user_name, conn_info.details.port)
+        return '{0}|{1}|{2}|{3}|{4}|{5}'.format(conn_info.details.options['host'], conn_info.details.options['dbname'], conn_info.details.options['user'], conn_info.details.options['port'], conn_info.details.options['authenticationType'], conn_info.details.options['groupId'])
 
     def _create_connection(self, connection_key: str, conn_info: ConnectionInfo, request_context: RequestContext) -> Optional[ServerConnection]:
         conn_service = self._connection_service

--- a/ossdbtoolsservice/language/operations_queue.py
+++ b/ossdbtoolsservice/language/operations_queue.py
@@ -160,7 +160,7 @@ class OperationsQueue:
         """
         Creates a key uniquely identifying a ConnectionInfo object for use in caching
         """
-        return '{0}|{1}|{2}|{3}|{4}|{5}'.format(conn_info.details.options['host'], conn_info.details.options['dbname'], conn_info.details.options['user'], conn_info.details.options['port'], conn_info.details.options['authenticationType'], conn_info.details.options['groupId'])
+        return utils.generate_session_uri(conn_info.details)
 
     def _create_connection(self, connection_key: str, conn_info: ConnectionInfo, request_context: RequestContext) -> Optional[ServerConnection]:
         conn_service = self._connection_service

--- a/ossdbtoolsservice/object_explorer/object_explorer_service.py
+++ b/ossdbtoolsservice/object_explorer/object_explorer_service.py
@@ -89,8 +89,11 @@ class ObjectExplorerService(object):
             # Generate the session ID and create/store the session
             session_id = self._generate_session_uri(params, self._provider)
             session : ObjectExplorerSession = None
+            is_new_session: bool = True
+            
             if session_id in self._session_map:
                 session = self._session_map[session_id]
+                is_new_session = False
             else:
                 session = ObjectExplorerSession(session_id, params)
                 # Add the session to session map in a lock to prevent race conditions between check and add
@@ -111,7 +114,7 @@ class ObjectExplorerService(object):
 
         # Step 2: Connect the session and lookup the root node asynchronously
         try:
-            session.init_task = threading.Thread(target=self._initialize_session, args=(request_context, session))
+            session.init_task = threading.Thread(target=self._initialize_session, args=(request_context, session, is_new_session))
             session.init_task.daemon = True
             session.init_task.start()
         except Exception as e:
@@ -264,28 +267,30 @@ class ObjectExplorerService(object):
         connection = conn_service.get_connection(key_uri, ConnectionType.OBJECT_EXLPORER, request_context)
         return connection
 
-    def _initialize_session(self, request_context: RequestContext, session: ObjectExplorerSession):
+    def _initialize_session(self, request_context: RequestContext, session: ObjectExplorerSession, is_new_session: bool = True):
         conn_service = self._service_provider[utils.constants.CONNECTION_SERVICE_NAME]
         connection = None
 
         try:
-            # Step 1: Connect with the provided connection details
-            connect_request = ConnectRequestParams(
-                session.connection_details,
-                session.id,
-                ConnectionType.OBJECT_EXLPORER
-            )
-            connect_result = conn_service.connect(connect_request, request_context)
-            if connect_result is None:
-                raise RuntimeError('Connection was cancelled during connect')   # TODO Localize
-            if connect_result.error_message is not None:
-                raise RuntimeError(connect_result.error_message)
+            if is_new_session:
+                # Step 1: Connect with the provided connection details
+                connect_request = ConnectRequestParams(
+                    session.connection_details,
+                    session.id,
+                    ConnectionType.OBJECT_EXLPORER
+                )
+                connect_result = conn_service.connect(connect_request, request_context)
+                if connect_result is None:
+                    raise RuntimeError('Connection was cancelled during connect')   # TODO Localize
+                if connect_result.error_message is not None:
+                    raise RuntimeError(connect_result.error_message)
 
-            # Step 2: Get the connection to use for object explorer
-            connection = conn_service.get_connection(session.id, ConnectionType.OBJECT_EXLPORER, request_context)
+                # Step 2: Get the connection to use for object explorer
+                connection = conn_service.get_connection(session.id, ConnectionType.OBJECT_EXLPORER, request_context)
 
-            # Step 3: Create the Server object for the session and create the root node for the server
-            session.server = self._server(connection, functools.partial(self._create_connection, session, request_context=request_context))
+                # Step 3: Create the Server object for the session and create the root node for the server
+                session.server = self._server(connection, functools.partial(self._create_connection, session, request_context=request_context))
+
             metadata = ObjectMetadata(session.server.urn_base, None, 'Database', session.server.maintenance_db_name)
             node = NodeInfo()
             node.label = session.connection_details.database_name

--- a/ossdbtoolsservice/object_explorer/object_explorer_service.py
+++ b/ossdbtoolsservice/object_explorer/object_explorer_service.py
@@ -336,21 +336,7 @@ class ObjectExplorerService(object):
 
     @staticmethod
     def _generate_session_uri(params: ConnectionDetails, provider_name: str) -> str:
-        # Make sure the required params are provided
-        utils.validate.is_not_none_or_whitespace('params.server_name', params.options.get('host'))
-        utils.validate.is_not_none_or_whitespace('params.user_name', params.options.get('user'))
-        utils.validate.is_not_none('params.port', params.options.get('port'))
-
-        # Generates a session ID that will function as the base URI for the session
-        host = quote(params.options['host'])
-        user = quote(params.options['user'])
-        db = quote(params.options['dbname'])
-        group_id = quote(params.options['groupId'])
-        authentication_type = quote(params.options['authenticationType'])
-        # Port number distinguishes between connections to different server instances with the same username, dbname running on same host
-        port = quote(str(params.options['port']))
-        
-        return f'objectexplorer://{user}@{host}:{port}:{db}:{authentication_type}:{group_id}/'
+        return "objectexplorer://{0}/".format(utils.generate_session_uri(params))
 
     def _route_request(self, is_refresh: bool, session: ObjectExplorerSession, path: str) -> List[NodeInfo]:
         """

--- a/ossdbtoolsservice/object_explorer/object_explorer_service.py
+++ b/ossdbtoolsservice/object_explorer/object_explorer_service.py
@@ -88,19 +88,15 @@ class ObjectExplorerService(object):
 
             # Generate the session ID and create/store the session
             session_id = self._generate_session_uri(params, self._provider)
-
             session : ObjectExplorerSession = None
-            is_new_session: bool = True
-            
             if session_id in self._session_map:
                 session = self._session_map[session_id]
-                is_new_session = False
             else:
                 session = ObjectExplorerSession(session_id, params)
                 # Add the session to session map in a lock to prevent race conditions between check and add
                 with self._session_lock:
                     self._session_map[session_id] = session
-
+                    
             # Respond that the session was created
             response = CreateSessionResponse(session_id)
             request_context.send_response(response)
@@ -112,10 +108,10 @@ class ObjectExplorerService(object):
             send_error_telemetry_notification(request_context, OssdbErrorConstants.OBJECT_EXPLORER, OssdbErrorConstants.OBJECT_EXPLORER_CREATE_SESSION, OssdbErrorConstants.OBJECT_EXPLORER_CREATE_SESSION_ERROR)
             request_context.send_error(message=message, code=OssdbErrorConstants.OBJECT_EXPLORER_CREATE_SESSION_ERROR)
             return
-        
+
         # Step 2: Connect the session and lookup the root node asynchronously
         try:
-            session.init_task = threading.Thread(target=self._initialize_session, args=(request_context, session, is_new_session))
+            session.init_task = threading.Thread(target=self._initialize_session, args=(request_context, session))
             session.init_task.daemon = True
             session.init_task.start()
         except Exception as e:
@@ -268,30 +264,28 @@ class ObjectExplorerService(object):
         connection = conn_service.get_connection(key_uri, ConnectionType.OBJECT_EXLPORER, request_context)
         return connection
 
-    def _initialize_session(self, request_context: RequestContext, session: ObjectExplorerSession, is_new_session: bool = True):
+    def _initialize_session(self, request_context: RequestContext, session: ObjectExplorerSession):
         conn_service = self._service_provider[utils.constants.CONNECTION_SERVICE_NAME]
         connection = None
 
         try:
-            if is_new_session:
-                # Step 1: Connect with the provided connection details
-                connect_request = ConnectRequestParams(
-                    session.connection_details,
-                    session.id,
-                    ConnectionType.OBJECT_EXLPORER
-                )
-                connect_result = conn_service.connect(connect_request, request_context)
-                if connect_result is None:
-                    raise RuntimeError('Connection was cancelled during connect')   # TODO Localize
-                if connect_result.error_message is not None:
-                    raise RuntimeError(connect_result.error_message)
+            # Step 1: Connect with the provided connection details
+            connect_request = ConnectRequestParams(
+                session.connection_details,
+                session.id,
+                ConnectionType.OBJECT_EXLPORER
+            )
+            connect_result = conn_service.connect(connect_request, request_context)
+            if connect_result is None:
+                raise RuntimeError('Connection was cancelled during connect')   # TODO Localize
+            if connect_result.error_message is not None:
+                raise RuntimeError(connect_result.error_message)
 
-                # Step 2: Get the connection to use for object explorer
-                connection = conn_service.get_connection(session.id, ConnectionType.OBJECT_EXLPORER, request_context)
+            # Step 2: Get the connection to use for object explorer
+            connection = conn_service.get_connection(session.id, ConnectionType.OBJECT_EXLPORER, request_context)
 
-                # Step 3: Create the Server object for the session and create the root node for the server
-                session.server = self._server(connection, functools.partial(self._create_connection, session, request_context=request_context))
-
+            # Step 3: Create the Server object for the session and create the root node for the server
+            session.server = self._server(connection, functools.partial(self._create_connection, session, request_context=request_context))
             metadata = ObjectMetadata(session.server.urn_base, None, 'Database', session.server.maintenance_db_name)
             node = NodeInfo()
             node.label = session.connection_details.database_name

--- a/ossdbtoolsservice/object_explorer/object_explorer_service.py
+++ b/ossdbtoolsservice/object_explorer/object_explorer_service.py
@@ -88,12 +88,15 @@ class ObjectExplorerService(object):
 
             # Generate the session ID and create/store the session
             session_id = self._generate_session_uri(params, self._provider)
-            session: ObjectExplorerSession = ObjectExplorerSession(session_id, params)
-
-            # Add the session to session map in a lock to prevent race conditions between check and add
-            with self._session_lock:
-                self._session_map[session_id] = session
-
+            session : ObjectExplorerSession = None
+            if session_id in self._session_map:
+                session = self._session_map[session_id]
+            else:
+                session = ObjectExplorerSession(session_id, params)
+                # Add the session to session map in a lock to prevent race conditions between check and add
+                with self._session_lock:
+                    self._session_map[session_id] = session
+                    
             # Respond that the session was created
             response = CreateSessionResponse(session_id)
             request_context.send_response(response)

--- a/ossdbtoolsservice/object_explorer/object_explorer_service.py
+++ b/ossdbtoolsservice/object_explorer/object_explorer_service.py
@@ -92,13 +92,6 @@ class ObjectExplorerService(object):
 
             # Add the session to session map in a lock to prevent race conditions between check and add
             with self._session_lock:
-                if session_id in self._session_map:
-                    # Removed the exception for now. But we need to investigate why we would get this
-                    if self._service_provider.logger is not None:
-                        self._service_provider.logger.error(f'Object explorer session for {session_id} already exists!')
-                    request_context.send_response(False)
-                    return
-
                 self._session_map[session_id] = session
 
             # Respond that the session was created

--- a/ossdbtoolsservice/object_explorer/object_explorer_service.py
+++ b/ossdbtoolsservice/object_explorer/object_explorer_service.py
@@ -88,15 +88,19 @@ class ObjectExplorerService(object):
 
             # Generate the session ID and create/store the session
             session_id = self._generate_session_uri(params, self._provider)
+
             session : ObjectExplorerSession = None
+            is_new_session: bool = True
+            
             if session_id in self._session_map:
                 session = self._session_map[session_id]
+                is_new_session = False
             else:
                 session = ObjectExplorerSession(session_id, params)
                 # Add the session to session map in a lock to prevent race conditions between check and add
                 with self._session_lock:
                     self._session_map[session_id] = session
-                    
+
             # Respond that the session was created
             response = CreateSessionResponse(session_id)
             request_context.send_response(response)
@@ -108,10 +112,10 @@ class ObjectExplorerService(object):
             send_error_telemetry_notification(request_context, OssdbErrorConstants.OBJECT_EXPLORER, OssdbErrorConstants.OBJECT_EXPLORER_CREATE_SESSION, OssdbErrorConstants.OBJECT_EXPLORER_CREATE_SESSION_ERROR)
             request_context.send_error(message=message, code=OssdbErrorConstants.OBJECT_EXPLORER_CREATE_SESSION_ERROR)
             return
-
+        
         # Step 2: Connect the session and lookup the root node asynchronously
         try:
-            session.init_task = threading.Thread(target=self._initialize_session, args=(request_context, session))
+            session.init_task = threading.Thread(target=self._initialize_session, args=(request_context, session, is_new_session))
             session.init_task.daemon = True
             session.init_task.start()
         except Exception as e:
@@ -264,28 +268,30 @@ class ObjectExplorerService(object):
         connection = conn_service.get_connection(key_uri, ConnectionType.OBJECT_EXLPORER, request_context)
         return connection
 
-    def _initialize_session(self, request_context: RequestContext, session: ObjectExplorerSession):
+    def _initialize_session(self, request_context: RequestContext, session: ObjectExplorerSession, is_new_session: bool = True):
         conn_service = self._service_provider[utils.constants.CONNECTION_SERVICE_NAME]
         connection = None
 
         try:
-            # Step 1: Connect with the provided connection details
-            connect_request = ConnectRequestParams(
-                session.connection_details,
-                session.id,
-                ConnectionType.OBJECT_EXLPORER
-            )
-            connect_result = conn_service.connect(connect_request, request_context)
-            if connect_result is None:
-                raise RuntimeError('Connection was cancelled during connect')   # TODO Localize
-            if connect_result.error_message is not None:
-                raise RuntimeError(connect_result.error_message)
+            if is_new_session:
+                # Step 1: Connect with the provided connection details
+                connect_request = ConnectRequestParams(
+                    session.connection_details,
+                    session.id,
+                    ConnectionType.OBJECT_EXLPORER
+                )
+                connect_result = conn_service.connect(connect_request, request_context)
+                if connect_result is None:
+                    raise RuntimeError('Connection was cancelled during connect')   # TODO Localize
+                if connect_result.error_message is not None:
+                    raise RuntimeError(connect_result.error_message)
 
-            # Step 2: Get the connection to use for object explorer
-            connection = conn_service.get_connection(session.id, ConnectionType.OBJECT_EXLPORER, request_context)
+                # Step 2: Get the connection to use for object explorer
+                connection = conn_service.get_connection(session.id, ConnectionType.OBJECT_EXLPORER, request_context)
 
-            # Step 3: Create the Server object for the session and create the root node for the server
-            session.server = self._server(connection, functools.partial(self._create_connection, session, request_context=request_context))
+                # Step 3: Create the Server object for the session and create the root node for the server
+                session.server = self._server(connection, functools.partial(self._create_connection, session, request_context=request_context))
+
             metadata = ObjectMetadata(session.server.urn_base, None, 'Database', session.server.maintenance_db_name)
             node = NodeInfo()
             node.label = session.connection_details.database_name

--- a/ossdbtoolsservice/object_explorer/object_explorer_service.py
+++ b/ossdbtoolsservice/object_explorer/object_explorer_service.py
@@ -345,11 +345,12 @@ class ObjectExplorerService(object):
         host = quote(params.options['host'])
         user = quote(params.options['user'])
         db = quote(params.options['dbname'])
-        # Port number distinguishes between connections to different server
-        # instances with the same username, dbname running on same host
+        group_id = quote(params.options['groupId'])
+        authentication_type = quote(params.options['authenticationType'])
+        # Port number distinguishes between connections to different server instances with the same username, dbname running on same host
         port = quote(str(params.options['port']))
-
-        return f'objectexplorer://{user}@{host}:{port}:{db}/'
+        
+        return f'objectexplorer://{user}@{host}:{port}:{db}:{authentication_type}:{group_id}/'
 
     def _route_request(self, is_refresh: bool, session: ObjectExplorerSession, path: str) -> List[NodeInfo]:
         """

--- a/ossdbtoolsservice/utils/__init__.py
+++ b/ossdbtoolsservice/utils/__init__.py
@@ -14,7 +14,7 @@ import ossdbtoolsservice.utils.thread
 import ossdbtoolsservice.utils.time
 import ossdbtoolsservice.utils.validate         # noqa
 import ossdbtoolsservice.utils.ip
-
+from ossdbtoolsservice.utils.session_uri import generate_session_uri
 __all__ = [
     'cancellation',
     'constants',
@@ -24,5 +24,6 @@ __all__ = [
     'time',
     'validate',
     'telemetryUtils',
-    'ip'
+    'ip',
+    'generate_session_uri'
 ]

--- a/ossdbtoolsservice/utils/session_uri.py
+++ b/ossdbtoolsservice/utils/session_uri.py
@@ -13,7 +13,7 @@ def generate_session_uri(params):
         params.options['host'] if is_not_none_or_empty(params.options['host']) else "NULL",
         params.options['dbname'] if is_not_none_or_empty(params.options['dbname']) else "NULL",
         params.options['user'] if is_not_none_or_empty(params.options['user']) else "NULL",
-        params.options['port'] if is_not_none_or_empty(params.options['port']) else "NULL",
+        params.options['port'] if is_not_none_or_empty(str(params.options['port'])) else "NULL",
         params.options['authenticationType'] if is_not_none_or_empty(params.options['authenticationType']) else "NULL",
         params.options['groupId'] if is_not_none_or_empty(params.options['groupId']) else "NULL"
     )

--- a/ossdbtoolsservice/utils/session_uri.py
+++ b/ossdbtoolsservice/utils/session_uri.py
@@ -10,11 +10,11 @@ def is_none_or_empty(value_to_check: str):
 
 def generate_session_uri(params):
     session_uri = "{0}:{1}:{2}:{3}:{4}:{5}".format(
-        params.options['host'] if not params.options.get('host') or is_none_or_empty(params.options.get('host')) else 'NULL',
-        params.options['dbname'] if not params.options.get('dbname') or is_none_or_empty(params.options.get('dbname')) else 'NULL',
-        params.options['user'] if not params.options.get('user') or is_none_or_empty(params.options.get('user')) else 'NULL',
-        params.options['port'] if not params.options.get('port') or is_none_or_empty(params.options.get('port')) else 'NULL',
-        params.options['authenticationType'] if not params.options.get('authenticationType') or is_none_or_empty(params.options.get('authenticationType')) else 'NULL',
-        params.options['groupId'] if not params.options.get('groupId') or is_none_or_empty(params.options.get('groupId')) else 'NULL'
+        params.options['host'] if params.options.get('host') and not is_none_or_empty(params.options.get('host')) else 'NULL',
+        params.options['dbname'] if params.options.get('dbname') and not is_none_or_empty(params.options.get('dbname')) else 'NULL',
+        params.options['user'] if params.options.get('user') and not is_none_or_empty(params.options.get('user')) else 'NULL',
+        params.options['port'] if params.options.get('port') and not is_none_or_empty(params.options.get('port')) else 'NULL',
+        params.options['authenticationType'] if params.options.get('authenticationType') and not is_none_or_empty(params.options.get('authenticationType')) else 'NULL',
+        params.options['groupId'] if params.options.get('groupId') and not is_none_or_empty(params.options.get('groupId')) else 'NULL'
     )
     return session_uri

--- a/ossdbtoolsservice/utils/session_uri.py
+++ b/ossdbtoolsservice/utils/session_uri.py
@@ -8,28 +8,13 @@ def is_none_or_empty(value_to_check: str):
         return True
     return False
 
-def validate_params(params):
-    if not params.options.get('host') or is_none_or_empty(params.options.get('host')):
-        params.options['host'] = 'NULL'
-    if not params.options.get('dbname') or is_none_or_empty(params.options.get('dbname')):
-        params.options['dbname'] = 'NULL'
-    if not params.options.get('user') or is_none_or_empty(params.options.get('user')):
-        params.options['user'] = 'NULL'
-    if not params.options.get('port') or is_none_or_empty(params.options.get('port')):
-        params.options['port'] = 'NULL'
-    if not params.options.get('authenticationType') or is_none_or_empty(params.options.get('authenticationType')):
-        params.options['authenticationType'] = 'NULL'
-    if not params.options.get('groupId') or is_none_or_empty(params.options.get('groupId')):
-        params.options['groupId'] = 'NULL'
-
 def generate_session_uri(params):
-    validate_params(params)
     session_uri = "{0}:{1}:{2}:{3}:{4}:{5}".format(
-        params.options['host'],
-        params.options['dbname'],
-        params.options['user'],
-        params.options['port'],
-        params.options['authenticationType'],
-        params.options['groupId']
+        params.options['host'] if not params.options.get('host') or is_none_or_empty(params.options.get('host')) else 'NULL',
+        params.options['dbname'] if not params.options.get('dbname') or is_none_or_empty(params.options.get('dbname')) else 'NULL',
+        params.options['user'] if not params.options.get('user') or is_none_or_empty(params.options.get('user')) else 'NULL',
+        params.options['port'] if not params.options.get('port') or is_none_or_empty(params.options.get('port')) else 'NULL',
+        params.options['authenticationType'] if not params.options.get('authenticationType') or is_none_or_empty(params.options.get('authenticationType')) else 'NULL',
+        params.options['groupId'] if not params.options.get('groupId') or is_none_or_empty(params.options.get('groupId')) else 'NULL'
     )
     return session_uri

--- a/ossdbtoolsservice/utils/session_uri.py
+++ b/ossdbtoolsservice/utils/session_uri.py
@@ -3,8 +3,8 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-def is_none_or_empty(value_to_check: str):
-    if value_to_check is None or len(value_to_check.strip()) == 0:
+def is_none_or_empty(value_to_check):
+    if value_to_check is None or len(str(value_to_check).strip()) == 0:
         return True
     return False
 

--- a/ossdbtoolsservice/utils/session_uri.py
+++ b/ossdbtoolsservice/utils/session_uri.py
@@ -3,14 +3,12 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from ossdbtoolsservice.utils.constants import DEFAULT_PORT
-
 def is_none_or_empty(value_to_check: str):
     if value_to_check is None or len(value_to_check.strip()) == 0:
         return True
     return False
 
-def validate_params(provider, params):
+def validate_params(params):
     if not params.options.get('host') or is_none_or_empty(params.options.get('host')):
         params.options['host'] = 'NULL'
     if not params.options.get('dbname') or is_none_or_empty(params.options.get('dbname')):
@@ -18,14 +16,14 @@ def validate_params(provider, params):
     if not params.options.get('user') or is_none_or_empty(params.options.get('user')):
         params.options['user'] = 'NULL'
     if not params.options.get('port') or is_none_or_empty(params.options.get('port')):
-        params.options['port'] = DEFAULT_PORT[provider]
+        params.options['port'] = 'NULL'
     if not params.options.get('authenticationType') or is_none_or_empty(params.options.get('authenticationType')):
         params.options['authenticationType'] = 'NULL'
     if not params.options.get('groupId') or is_none_or_empty(params.options.get('groupId')):
         params.options['groupId'] = 'NULL'
 
-def generate_session_uri(provider, params):
-    validate_params(provider, params)
+def generate_session_uri(params):
+    validate_params(params)
     session_uri = "{0}:{1}:{2}:{3}:{4}:{5}".format(
         params.options['host'],
         params.options['dbname'],

--- a/ossdbtoolsservice/utils/session_uri.py
+++ b/ossdbtoolsservice/utils/session_uri.py
@@ -3,8 +3,8 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-def is_none_or_empty(value_to_check):
-    if value_to_check is None or len(str(value_to_check).strip()) == 0:
+def is_none_or_empty(value_to_check: str):
+    if value_to_check is None or len(value_to_check.strip()) == 0:
         return True
     return False
 
@@ -13,7 +13,7 @@ def generate_session_uri(params):
         params.options['host'] if params.options.get('host') and not is_none_or_empty(params.options.get('host')) else 'NULL',
         params.options['dbname'] if params.options.get('dbname') and not is_none_or_empty(params.options.get('dbname')) else 'NULL',
         params.options['user'] if params.options.get('user') and not is_none_or_empty(params.options.get('user')) else 'NULL',
-        params.options['port'] if params.options.get('port') and not is_none_or_empty(params.options.get('port')) else 'NULL',
+        params.options['port'] if params.options.get('port') and not is_none_or_empty(str(params.options.get('port'))) else 'NULL',
         params.options['authenticationType'] if params.options.get('authenticationType') and not is_none_or_empty(params.options.get('authenticationType')) else 'NULL',
         params.options['groupId'] if params.options.get('groupId') and not is_none_or_empty(params.options.get('groupId')) else 'NULL'
     )

--- a/ossdbtoolsservice/utils/session_uri.py
+++ b/ossdbtoolsservice/utils/session_uri.py
@@ -1,0 +1,20 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+def is_not_none_or_empty(value_to_check: str):
+    if value_to_check is None or len(value_to_check.strip()) == 0:
+        return False
+    return True
+
+def generate_session_uri(params):
+    session_uri = "{0}:{1}:{2}:{3}:{4}:{5}".format(
+        params.options['host'] if is_not_none_or_empty(params.options['host']) else "NULL",
+        params.options['dbname'] if is_not_none_or_empty(params.options['dbname']) else "NULL",
+        params.options['user'] if is_not_none_or_empty(params.options['user']) else "NULL",
+        params.options['port'] if is_not_none_or_empty(params.options['port']) else "NULL",
+        params.options['authenticationType'] if is_not_none_or_empty(params.options['authenticationType']) else "NULL",
+        params.options['groupId'] if is_not_none_or_empty(params.options['groupId']) else "NULL"
+    )
+    return session_uri

--- a/ossdbtoolsservice/utils/session_uri.py
+++ b/ossdbtoolsservice/utils/session_uri.py
@@ -3,18 +3,35 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-def is_not_none_or_empty(value_to_check: str):
-    if value_to_check is None or len(value_to_check.strip()) == 0:
-        return False
-    return True
+from ossdbtoolsservice.utils.constants import DEFAULT_PORT
 
-def generate_session_uri(params):
+def is_none_or_empty(value_to_check: str):
+    if value_to_check is None or len(value_to_check.strip()) == 0:
+        return True
+    return False
+
+def validate_params(provider, params):
+    if not params.options.get('host') or is_none_or_empty(params.options.get('host')):
+        params.options['host'] = 'NULL'
+    if not params.options.get('dbname') or is_none_or_empty(params.options.get('dbname')):
+        params.options['dbname'] = 'NULL'
+    if not params.options.get('user') or is_none_or_empty(params.options.get('user')):
+        params.options['user'] = 'NULL'
+    if not params.options.get('port') or is_none_or_empty(params.options.get('port')):
+        params.options['port'] = DEFAULT_PORT[provider]
+    if not params.options.get('authenticationType') or is_none_or_empty(params.options.get('authenticationType')):
+        params.options['authenticationType'] = 'NULL'
+    if not params.options.get('groupId') or is_none_or_empty(params.options.get('groupId')):
+        params.options['groupId'] = 'NULL'
+
+def generate_session_uri(provider, params):
+    validate_params(provider, params)
     session_uri = "{0}:{1}:{2}:{3}:{4}:{5}".format(
-        params.options['host'] if is_not_none_or_empty(params.options['host']) else "NULL",
-        params.options['dbname'] if is_not_none_or_empty(params.options['dbname']) else "NULL",
-        params.options['user'] if is_not_none_or_empty(params.options['user']) else "NULL",
-        params.options['port'] if is_not_none_or_empty(str(params.options['port'])) else "NULL",
-        params.options['authenticationType'] if is_not_none_or_empty(params.options['authenticationType']) else "NULL",
-        params.options['groupId'] if is_not_none_or_empty(params.options['groupId']) else "NULL"
+        params.options['host'],
+        params.options['dbname'],
+        params.options['user'],
+        params.options['port'],
+        params.options['authenticationType'],
+        params.options['groupId']
     )
     return session_uri


### PR DESCRIPTION
Issue https://github.com/microsoft/azuredatastudio-mysql/issues/96:
If there was an existing object explorer session, when we try to edit connection and connect without changing any parameters, the object explorer tab does not expand because of this check. 

Solution:
Removing this check overrides the current object explorer session in the session map with this new session and calls all the operations again which include expand node.

It seems sqltoolsservice also does not do this check https://github.com/microsoft/sqltoolsservice/blob/f288bee29418fd205a9d14e3c3a4cac360caa11d/src/Microsoft.SqlTools.ServiceLayer/ObjectExplorer/ObjectExplorerService.cs#L171 


Creating a common pattern for session_uri key and a common function in util to generate it.
sqltoolsservice uses a common function to generate uri's: https://github.com/microsoft/sqltoolsservice/blob/f288bee29418fd205a9d14e3c3a4cac360caa11d/src/Microsoft.SqlTools.ServiceLayer/LanguageServices/ConnectedBindingQueue.cs#L92


This PR also fixes:
https://github.com/microsoft/azuredatastudio-mysql/issues/200
